### PR TITLE
Scala.JS to 0.6.2

### DIFF
--- a/project/scalajs.sbt
+++ b/project/scalajs.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.2")
 
 resolvers += Resolver.url(
   "bintray-sbt-plugin-releases",


### PR DESCRIPTION
There was a bug in Scala.JS 0.6.0 that needed all libraries to be published with 0.6.1+.

0.6.2's IR is backwards compatible with 0.6.0 and 0.6.1.